### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -105,7 +105,7 @@ async def verify_api_key(
         )
 
     if x_api_key != expected_key:
-        logger.warning(f"Invalid API key provided: {x_api_key[:8]}...")
+        logger.warning("Invalid API key provided")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid API key",


### PR DESCRIPTION
Potential fix for [https://github.com/ramesh-pegasys/csp-scanner/security/code-scanning/2](https://github.com/ramesh-pegasys/csp-scanner/security/code-scanning/2)

The issue can be fixed by removing the actual API key value (even in partial or masked form) from log messages. Instead, log only generic information (such as that an invalid API key was provided), which is enough for admins to understand that authentication failed, without exposing sensitive information. Only make changes to the relevant log message at line 108 of `app/api/dependencies.py`. No new methods or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
